### PR TITLE
chore: parse creator address in UploadFile

### DIFF
--- a/x/filehash/keeper/keeper.go
+++ b/x/filehash/keeper/keeper.go
@@ -76,9 +76,13 @@ func (k Keeper) UploadFile(goCtx context.Context, msg *types.MsgUploadFile) (*ty
 		return nil, err
 	}
 	// Send from module to user
-	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, sdk.AccAddress(msg.Creator), coins); err != nil {
-		return nil, err
-	}
+        addr, err := sdk.AccAddressFromBech32(msg.Creator)
+        if err != nil {
+                return nil, err
+        }
+        if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, coins); err != nil {
+                return nil, err
+        }
 
 	return &types.MsgUploadFileResponse{Success: true}, nil
 }


### PR DESCRIPTION
## Summary
- parse creator address using `sdk.AccAddressFromBech32` and propagate errors in `UploadFile`

## Testing
- `go test ./...` *(fails: command not found: go)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b4adb11c83278fb711965e4eb054