### PR TITLE
add fix-keyring CLI command

### DIFF
--- a/cmd/doctoriumd/fix_keyring.go
+++ b/cmd/doctoriumd/fix_keyring.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/cosmos/cosmos-sdk/client"
+    "github.com/cosmos/cosmos-sdk/crypto/keyring"
+    "github.com/spf13/cobra"
+)
+
+// newFixKeyringCmd returns a command that detects a corrupted keyring-file and
+// recreates it. This is useful when operations like `keys add` or `keys show`
+// fail with "Bytes left over in UnmarshalBinaryLengthPrefixed" errors due to
+// malformed data.
+func newFixKeyringCmd() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "fix-keyring",
+        Short: "Detect and remove a corrupted keyring-file",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            clientCtx := client.GetClientContextFromCmd(cmd)
+            kr, err := keyring.New(clientCtx.Codec, "doctorium", keyring.BackendFile, clientCtx.HomeDir, cmd.InOrStdin())
+            if err != nil {
+                return err
+            }
+            if _, err := kr.List(); err != nil {
+                if !strings.Contains(err.Error(), "Bytes left over") &&
+                    !strings.Contains(err.Error(), "UnmarshalBinaryLengthPrefixed") &&
+                    !strings.Contains(strings.ToLower(err.Error()), "unmarshal") {
+                    return err
+                }
+                keyringDir := filepath.Join(clientCtx.HomeDir, "keyring-file")
+                if rmErr := os.RemoveAll(keyringDir); rmErr != nil {
+                    return rmErr
+                }
+                fmt.Fprintf(cmd.OutOrStdout(), "Removed corrupted keyring at %s\n", keyringDir)
+                return nil
+            }
+            fmt.Fprintln(cmd.OutOrStdout(), "keyring is healthy")
+            return nil
+        },
+    }
+    return cmd
+}
+

--- a/cmd/doctoriumd/main.go
+++ b/cmd/doctoriumd/main.go
@@ -68,10 +68,10 @@ func main() {
 
 	// 4) genesis 계열 서브커맨드 등록
 	balIter := banktypes.GenesisBalancesIterator{}
-	rootCmd.AddCommand(
+       rootCmd.AddCommand(
 
-		//authcli.AddGenesisAccountCmd(app.DefaultNodeHome),
-		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
+                //authcli.AddGenesisAccountCmd(app.DefaultNodeHome),
+                genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.GenTxCmd(app.ModuleBasics, encCfg.TxConfig, balIter, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(balIter, app.DefaultNodeHome, genutiltypes.DefaultMessageValidator),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
@@ -81,9 +81,10 @@ func main() {
 		),
 	)
 
-	rootCmd.AddCommand(
-		keyscli.Commands(app.DefaultNodeHome),
-	)
+       rootCmd.AddCommand(
+                keyscli.Commands(app.DefaultNodeHome),
+               newFixKeyringCmd(),
+       )
 
 	// 5) tendermint init, start, unsafe-reset-all 등 노드 실행 커맨드 등록
 	sdkserver.AddCommands(


### PR DESCRIPTION
## Summary
- add `fix-keyring` command to remove corrupted keyring-file
- register command with root CLI so users can repair key storage when `keys` commands fail
- fix keyring creation by passing codec to `keyring.New`

## Testing
- `apt-get update` *(fails: 403 Forbidden, repo not signed)*
- `apt-get install -y golang-go` *(fails: Unable to locate package golang-go)*
- `gofmt -w cmd/doctoriumd/fix_keyring.go cmd/doctoriumd/main.go` *(fails: command not found)*
- `go test ./...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ae1de090832785f5f4a55f28c371