### PR TITLE
chore: validate genesis with message validator

### DIFF
--- a/cmd/doctoriumd/main.go
+++ b/cmd/doctoriumd/main.go
@@ -73,8 +73,8 @@ func main() {
                 //authcli.AddGenesisAccountCmd(app.DefaultNodeHome),
                 genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.GenTxCmd(app.ModuleBasics, encCfg.TxConfig, balIter, app.DefaultNodeHome),
-		genutilcli.CollectGenTxsCmd(balIter, app.DefaultNodeHome, genutiltypes.DefaultMessageValidator),
-		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
+                genutilcli.CollectGenTxsCmd(balIter, app.DefaultNodeHome, genutiltypes.DefaultMessageValidator),
+                genutilcli.ValidateGenesisCmd(app.ModuleBasics, genutiltypes.DefaultMessageValidator),
 
 		genutilcli.AddGenesisAccountCmd(
 			app.DefaultNodeHome,


### PR DESCRIPTION
## Summary
- pass message validator to `validate-genesis` CLI command to match Cosmos SDK 0.47 API

## Testing
- `go test ./...` *(fails: command not found: go)*
- `go build ./cmd/doctoriumd` *(fails: command not found: go)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b8c76acc83279b9d782222ff9db8