### PR TITLE
chore: pass message validator to validate-genesis

### DIFF
--- a/cmd/doctoriumd/main.go
+++ b/cmd/doctoriumd/main.go
@@ -73,8 +73,8 @@ func main() {
                 //authcli.AddGenesisAccountCmd(app.DefaultNodeHome),
                 genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.GenTxCmd(app.ModuleBasics, encCfg.TxConfig, balIter, app.DefaultNodeHome),
-		genutilcli.CollectGenTxsCmd(balIter, app.DefaultNodeHome, genutiltypes.DefaultMessageValidator),
-		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
+                genutilcli.CollectGenTxsCmd(balIter, app.DefaultNodeHome, genutiltypes.DefaultMessageValidator),
+                genutilcli.ValidateGenesisCmd(app.ModuleBasics, encCfg.TxConfig, genutiltypes.DefaultMessageValidator),
 
 		genutilcli.AddGenesisAccountCmd(
 			app.DefaultNodeHome,


### PR DESCRIPTION
## Summary
- wire TxConfig and message validator into ValidateGenesisCmd to align with CollectGenTxs

## Testing
- `go build ./cmd/doctoriumd` *(fails: command not found: go)*
- `go test ./...` *(fails: command not found: go)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b8c76acc83279b9d782222ff9db8