### PR TITLE
Expose tx subcommands on doctoriumd CLI

### DIFF
--- a/cmd/doctoriumd/main.go
+++ b/cmd/doctoriumd/main.go
@@ -7,12 +7,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/spf13/cobra"
+        "github.com/spf13/cobra"
 
-	// Cosmos SDK
-	"github.com/cosmos/cosmos-sdk/client"
-	sdkserver "github.com/cosmos/cosmos-sdk/server"     // ← 반드시 여기
-	servercmd "github.com/cosmos/cosmos-sdk/server/cmd" // Execute 용
+        // Cosmos SDK
+        "github.com/cosmos/cosmos-sdk/client"
+        tx "github.com/cosmos/cosmos-sdk/client/tx"
+        sdkserver "github.com/cosmos/cosmos-sdk/server"     // ← 반드시 여기
+        servercmd "github.com/cosmos/cosmos-sdk/server/cmd" // Execute 용
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/server/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -97,15 +98,19 @@ func main() {
 		),
 	)
 
-	rootCmd.AddCommand(
-		keyscli.Commands(app.DefaultNodeHome),
-		newFixKeyringCmd(),
-	)
+        rootCmd.AddCommand(
+                keyscli.Commands(app.DefaultNodeHome),
+                newFixKeyringCmd(),
+        )
 
-	// 5) tendermint init, start, unsafe-reset-all 등 노드 실행 커맨드 등록
-	sdkserver.AddCommands(
-		rootCmd,
-		app.DefaultNodeHome,
+        rootCmd.AddCommand(
+                tx.NewTxCmd(),
+        )
+
+        // 5) tendermint init, start, unsafe-reset-all 등 노드 실행 커맨드 등록
+        sdkserver.AddCommands(
+                rootCmd,
+                app.DefaultNodeHome,
 
 		// AppCreator
 		func(


### PR DESCRIPTION
## Summary
- import Cosmos SDK tx client package
- wire tx subcommands into doctoriumd root command

## Testing
- `make build` *(fails: go: No such file or directory)*
- `./build/doctoriumd tx decode --help` *(fails: cannot execute binary file: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ccb84ba88327b2e35a732edb4274